### PR TITLE
Only flatten if its a form field

### DIFF
--- a/wtforms_json/__init__.py
+++ b/wtforms_json/__init__.py
@@ -70,10 +70,13 @@ def flatten_json(
 
         new_key = parent_key + separator + key if parent_key else key
         if isinstance(value, collections.MutableMapping):
-            items.extend(
-                flatten_json(unbound_field.args[0], value, new_key)
-                .items()
-            )
+            if issubclass(field_class, FormField):
+                items.extend(
+                    flatten_json(unbound_field.args[0], value, new_key)
+                    .items()
+                )
+            else:
+                items.append((new_key, value))
         elif isinstance(value, list):
             if issubclass(field_class, FieldList):
                 items.extend(


### PR DESCRIPTION
There is some case where you dont want to flatten (I have some :)).
In fact, you only want to flatten on `FormField` because some special fields can handle `dict`.

This PR restricts `dict` flattening to `FormField` only.
