### PR TITLE
Fix process_formdata for python3

### DIFF
--- a/wtforms_json/__init__.py
+++ b/wtforms_json/__init__.py
@@ -252,7 +252,7 @@ def field_list_is_missing(self):
 
 def monkey_patch_process_formdata(func):
     def process_formdata(self, valuelist):
-        valuelist = map(six.text_type, valuelist)
+        valuelist = list(map(six.text_type, valuelist))
 
         return func(self, valuelist)
     return process_formdata


### PR DESCRIPTION
`map()` returns an iterator in python3, it needs to be cast to a list to work. 

Otherwise this error happens when `wtforms.ext.sqlalchemy.fields.QuerySelectField` tries to access it as a list:

```
Traceback (most recent call last):
  File "/var/www/app/website/venv/lib/python3.4/site-packages/werkzeug/test.py", line 784, in post
    return self.open(*args, **kw)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/testing.py", line 108, in open
    follow_redirects=follow_redirects)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/werkzeug/test.py", line 742, in open
    response = self.run_wsgi_app(environ, buffered=buffered)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/werkzeug/test.py", line 659, in run_wsgi_app
    rv = run_wsgi_app(self.application, environ, buffered=buffered)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/werkzeug/test.py", line 867, in run_wsgi_app
    app_iter = app(environ, start_response)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms/form.py", line 212, in __call__
    return type.__call__(cls, *args, **kwargs)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/flask_wtf/form.py", line 96, in __init__
    *args, **kwargs)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms/ext/csrf/form.py", line 21, in __init__
    super(SecureForm, self).__init__(formdata, obj, prefix, **kwargs)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms/form.py", line 278, in __init__
    self.process(formdata, obj, data=data, **kwargs)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms/form.py", line 128, in process
    field.process(formdata, getattr(obj, name))
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms_json/__init__.py", line 169, in process
    func(self, formdata, data=data)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms/fields/core.py", line 283, in process
    self.process_formdata(self.raw_data)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms_json/__init__.py", line 246, in process_formdata
    return func(self, valuelist)
  File "/var/www/app/website/venv/lib/python3.4/site-packages/wtforms/ext/sqlalchemy/fields.py", line 116, in process_formdata
    self._formdata = valuelist[0]
TypeError: 'map' object is not subscriptable
```