### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,13 +4,13 @@ wtforms-json
 Adds smart json support for `WTForms`_. Useful for when using WTForms with
 RESTful APIs.
 
-.. _WTForms: https://wtforms.readthedocs.org/en/latest/
+.. _WTForms: https://wtforms.readthedocs.io/en/latest/
 
 
 Resources
 ---------
 
-- `Documentation <http://wtforms-json.readthedocs.org/>`_
+- `Documentation <https://wtforms-json.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/kvesteri/wtforms-json/issues>`_
 - `Code <http://github.com/kvesteri/wtforms-json/>`_
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,5 +245,5 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'wtforms': ('http://wtforms.readthedocs.org/en/latest/', None)
+    'wtforms': ('https://wtforms.readthedocs.io/en/latest/', None)
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ WTForms-JSON
 
 WTForms-JSON is a `WTForms`_ extension for JSON data handling.
 
-.. _WTForms: https://wtforms.readthedocs.org/en/latest/
+.. _WTForms: https://wtforms.readthedocs.io/en/latest/
 
 What does it do?
 ----------------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
