### PR TITLE
Fixes issue #43 / issue384: patch_data should work with empty lists.

### DIFF
--- a/tests/test_patch_data.py
+++ b/tests/test_patch_data.py
@@ -88,6 +88,23 @@ class TestFormPatchData(object):
         form = EventForm.from_json(json)
         assert form.patch_data == json
 
+    def test_supports_empty_field_lists(self):
+        class Event(object):
+            def __init__(self, attendee_names):
+                self.name = "some name"
+                self.attendee_names = attendee_names
+
+        instance = Event(attendee_names=['Something'])
+        json = {
+            'name': 'some name',
+            'attendee_names': []
+        }
+        form = EventForm.from_json(json, obj=instance)
+        assert form.patch_data == dict(
+            attendee_names=(),
+            name="some name"
+        )
+
     def test_supports_null_values_for_form_fields(self):
         json = {
             'name': 'some name',

--- a/wtforms_json/__init__.py
+++ b/wtforms_json/__init__.py
@@ -136,6 +136,12 @@ def patch_data(self):
 
     for name, f in six.iteritems(self._fields):
         if f.is_missing:
+            default_value = f.default
+            if default_value == () and isinstance(f.object_data, list):
+                default_value = []
+            if not isinstance(f, FormField) and f.object_data != default_value and \
+               f.default is not None:
+                data[name] = f.default
             if is_optional(f):
                 continue
             elif not is_required(f) and f.default is None:


### PR DESCRIPTION
See ticket #43 

Not very elegant fix, but something to start with I guess.