### PR TITLE
support WTForms versions >= 3.0

### DIFF
--- a/tests/test_field_type_coercion.py
+++ b/tests/test_field_type_coercion.py
@@ -1,7 +1,11 @@
 import six  # noqa
 from pytest import mark
-from wtforms import Form, IntegerField, SelectMultipleField, TextField
-from wtforms.ext.sqlalchemy.fields import QuerySelectField
+from wtforms import Form, IntegerField, SelectMultipleField, StringField
+try:
+    from wtforms.ext.sqlalchemy.fields import QuerySelectField
+    HAS_SQLALCHEMY_SUPPORT = False
+except ImportError:
+    HAS_SQLALCHEMY_SUPPORT = False
 from wtforms.validators import IPAddress
 
 sa = None
@@ -15,7 +19,7 @@ except ImportError:
 class TestFieldTypeCoercion(object):
     def test_integer_to_unicode_coercion(self):
         class NetworkForm(Form):
-            address = TextField('Address', [IPAddress()])
+            address = StringField('Address', [IPAddress()])
 
         network = dict(address=123)
 
@@ -43,7 +47,7 @@ class FooForm(Form):
     )
 
 
-@mark.skipif('sa is None or six.PY3')
+@mark.skipif('sa is None or six.PY3 or not HAS_SQLALCHEMY_SUPPORT')
 class TestQuerySelectField(object):
     def setup_method(self, method):
         self.Base = declarative_base()

--- a/tests/test_json_decoder.py
+++ b/tests/test_json_decoder.py
@@ -7,7 +7,7 @@ from wtforms import (
     FormField,
     IntegerField,
     SelectMultipleField,
-    TextField
+    StringField,
 )
 
 from wtforms_json import flatten_json, InvalidData
@@ -76,7 +76,7 @@ class TestJsonDecoder(object):
 
     def test_supports_field_list_decoding(self):
         class MyForm(Form):
-            a = FieldList(TextField())
+            a = FieldList(StringField())
 
         assert flatten_json(MyForm, {'a': [1, 2, 3]}) == {
             'a-0': 1,
@@ -97,7 +97,7 @@ class TestJsonDecoder(object):
 
     def test_flatten_dict(self):
         class DeeplyNestedForm(Form):
-            c = TextField()
+            c = StringField()
 
         class NestedForm(Form):
             b = FormField(DeeplyNestedForm)
@@ -132,7 +132,7 @@ class TestJsonDecoder(object):
 
     def test_flatten_formfield_inheritance(self):
         class NestedForm(Form):
-            b = TextField()
+            b = StringField()
 
         class SpecialField(FormField):
             def __init__(self, *args, **kwargs):
@@ -149,7 +149,7 @@ class TestJsonDecoder(object):
         class SpecialField(FieldList):
             def __init__(self, *args, **kwargs):
                 super(SpecialField, self).__init__(
-                    TextField(),
+                    StringField(),
                     *args,
                     **kwargs
                 )
@@ -165,7 +165,7 @@ class TestJsonDecoder(object):
 
     def test_flatten_nested_listfield_and_formfield_inheritance(self):
         class NestedForm(Form):
-            b = TextField()
+            b = StringField()
 
         class SpecialNestedField(FormField):
             def __init__(self, *args, **kwargs):

--- a/tests/test_object_defaults.py
+++ b/tests/test_object_defaults.py
@@ -1,10 +1,10 @@
-from wtforms import Form, IntegerField, TextField
+from wtforms import Form, IntegerField, StringField
 from wtforms.validators import Optional
 
 
 class MyForm(Form):
     a = IntegerField(validators=[Optional()])
-    b = TextField()
+    b = StringField()
 
 
 def test_object_defaults():

--- a/tests/test_patch_data.py
+++ b/tests/test_patch_data.py
@@ -5,17 +5,17 @@ from wtforms import (
     Form,
     FormField,
     IntegerField,
-    TextField
+    StringField,
 )
-from wtforms.validators import Optional, Required
+from wtforms.validators import Optional, DataRequired
 
 from wtforms_json import InvalidData, MultiDict
 
 
 class BooleanTestForm(Form):
     is_active = BooleanField(default=False, validators=[Optional()])
-    is_confirmed = BooleanField(default=True, validators=[Required()])
-    is_private = BooleanField(default=False, validators=[Required()])
+    is_confirmed = BooleanField(default=True, validators=[DataRequired()])
+    is_private = BooleanField(default=False, validators=[DataRequired()])
 
 
 class TestPatchedBooleans(object):
@@ -31,16 +31,16 @@ class TestPatchedBooleans(object):
 
 
 class LocationForm(Form):
-    name = TextField()
+    name = StringField()
     longitude = IntegerField()
     latitude = IntegerField()
 
 
 class EventForm(Form):
-    name = TextField()
+    name = StringField()
     location = FormField(LocationForm)
     attendees = IntegerField()
-    attendee_names = FieldList(TextField())
+    attendee_names = FieldList(StringField())
 
 
 class TestSkipUnknownKeys(object):

--- a/tests/test_select_multiple_field.py
+++ b/tests/test_select_multiple_field.py
@@ -3,9 +3,9 @@ from wtforms import (
     SelectField,
     SelectFieldBase,
     SelectMultipleField,
-    TextField,
+    StringField,
     validators,
-    widgets
+    widgets,
 )
 
 
@@ -17,7 +17,7 @@ def test_select_field():
     ]
 
     class MomForm(Form):
-        name = TextField()
+        name = StringField()
         childs = SelectField(choices=((1, 1), (2, 2), (3, 3)), coerce=int)
 
     for fixture in fixtures:
@@ -33,7 +33,7 @@ def test_select_multiple_field():
     ]
 
     class AppleFanBoyForm(Form):
-        name = TextField()
+        name = StringField()
         gadgets = SelectMultipleField(
             choices=(
                 (1, 'Macbook Pro'),
@@ -41,7 +41,7 @@ def test_select_multiple_field():
                 (3, 'iPhone'),
                 (4, 'iPad')
             ),
-            validators=[validators.required()],
+            validators=[validators.DataRequired()],
             coerce=int
         )
 
@@ -86,9 +86,9 @@ def test_custom_field():
             return item in self.data
 
     class SuperHeroForm(Form):
-        name = TextField()
+        name = StringField()
         powers = SuperPowersField(
-            validators=[validators.required()]
+            validators=[validators.DataRequired()]
         )
 
     fixtures = [

--- a/wtforms_json/__init__.py
+++ b/wtforms_json/__init__.py
@@ -2,10 +2,14 @@ import collections
 
 import six
 from wtforms import Form
-from wtforms.ext.sqlalchemy.fields import (
-    QuerySelectField,
-    QuerySelectMultipleField
-)
+try:
+    from wtforms.ext.sqlalchemy.fields import (
+        QuerySelectField,
+        QuerySelectMultipleField
+    )
+    HAS_SQLALCHEMY_SUPPORT = True
+except ImportError:
+    HAS_SQLALCHEMY_SUPPORT = False
 from wtforms.fields import (
     _unset_value,
     BooleanField,
@@ -13,7 +17,7 @@ from wtforms.fields import (
     FieldList,
     FileField,
     FormField,
-    TextField
+    StringField
 )
 from wtforms.validators import DataRequired, Optional
 
@@ -187,7 +191,7 @@ def monkey_patch_field_process(func):
             self.form._is_missing = False
             self.form._patch_data = None
 
-        if isinstance(self, TextField) and not isinstance(self, FileField):
+        if isinstance(self, StringField) and not isinstance(self, FileField):
             if self.data is None:
                 self.data = u''
             else:
@@ -264,12 +268,14 @@ def init():
     Form.from_json = from_json
     Form.patch_data = patch_data
     FieldList.patch_data = patch_data
-    QuerySelectField.process_formdata = monkey_patch_process_formdata(
-        QuerySelectField.process_formdata
-    )
-    QuerySelectMultipleField.process_formdata = monkey_patch_process_formdata(
-        QuerySelectMultipleField.process_formdata
-    )
+    if HAS_SQLALCHEMY_SUPPORT:
+        QuerySelectField.process_formdata = monkey_patch_process_formdata(
+            QuerySelectField.process_formdata
+        )
+        QuerySelectMultipleField.process_formdata = \
+            monkey_patch_process_formdata(
+                QuerySelectMultipleField.process_formdata
+            )
     Field.process = monkey_patch_field_process(Field.process)
     FormField.process = monkey_patch_field_process(FormField.process)
     BooleanField.false_values = BooleanField.false_values + (False,)


### PR DESCRIPTION
WTForms 3.0 [removes](https://github.com/wtforms/wtforms/commit/60267825490e3e6653ee0b1ae2ef1fb56a1b340f) `TextField`, `Required`, and support for SQLAlchemy model forms.