### PR TITLE
Fixes (Python 3.6, tox, StringField default, latest versions...)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 env:
   matrix:
     - WTFORMS=WTForms==1.0.5
-    - WTFORMS=WTForms==2.0
+    - WTFORMS=WTForms==2.1
 
 install:
   - "pip install $WTFORMS"

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',

--- a/tests/test_object_defaults.py
+++ b/tests/test_object_defaults.py
@@ -1,3 +1,5 @@
+import pytest
+
 from wtforms import Form, IntegerField, StringField
 from wtforms.validators import Optional
 
@@ -5,17 +7,26 @@ from wtforms.validators import Optional
 class MyForm(Form):
     a = IntegerField(validators=[Optional()])
     b = StringField()
+    c = StringField(default='c')
 
 
-def test_object_defaults():
+class MyCallableForm(Form):
+    a = IntegerField(validators=[Optional()])
+    b = StringField()
+    c = StringField(default=lambda: 'c')
+
+
+@pytest.mark.parametrize('cls', [MyForm, MyCallableForm])
+def test_object_defaults(cls):
     class SomeClass(object):
         a = 1
         b = 'someone'
 
-    form = MyForm.from_json(obj=SomeClass())
-    assert form.data == {'a': 1, 'b': 'someone'}
+    form = cls.from_json(obj=SomeClass())
+    assert form.data == {'a': 1, 'b': 'someone', 'c': 'c'}
 
 
-def test_formdata_defaults():
-    form = MyForm.from_json({'a': 1, 'b': 'something'})
-    assert form.data == {'a': 1, 'b': 'something'}
+@pytest.mark.parametrize('cls', [MyForm, MyCallableForm])
+def test_formdata_defaults(cls):
+    form = cls.from_json({'a': 1, 'b': 'something'})
+    assert form.data == {'a': 1, 'b': 'something', 'c': 'c'}

--- a/tests/test_wtforms_alchemy.py
+++ b/tests/test_wtforms_alchemy.py
@@ -10,8 +10,8 @@ Session = sessionmaker(bind=engine)
 session = Session()
 
 
-class Test(Base):
-    __tablename__ = 'test'
+class Fake(Base):
+    __tablename__ = 'fake'
 
     id = sa.Column(sa.BigInteger, autoincrement=True, primary_key=True)
     a = sa.Column(sa.Unicode(100), nullable=True)
@@ -20,9 +20,10 @@ class Test(Base):
     d = sa.Column(sa.Unicode(255), nullable=True)
 
 
-class TestForm(ModelForm):
+class FakeForm(ModelForm):
     class Meta:
-        model = Test
+        model = Fake
+
 
 Base.metadata.create_all(engine)
 # Example
@@ -36,12 +37,12 @@ def create_form_from_json(**kwargs):
             'c': u'Third',
             'd': u'Fourth'
         }
-    return TestForm.from_json(kwargs['json'])
+    return FakeForm.from_json(kwargs['json'])
 
 
 def create_populated_obj_from_json_form():
     form = create_form_from_json()
-    obj = Test()
+    obj = Fake()
     form.populate_obj(obj)
     return obj
 
@@ -59,7 +60,7 @@ def test_init_formdata():
 
 def test_populate_form_from_object():
     obj = create_populated_obj_from_json_form()
-    form = TestForm(obj=obj)
+    form = FakeForm(obj=obj)
     assert len(form.data) == 4
     for key in form.data:
         assert form.data[key] == obj.__dict__[key]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = {py26,py27,py33,py34,pypy}-{wtf,wtf2}
+envlist = {py27,py33,py34,py35,py36}-{wtf,wtf2}
 
 [testenv]
 commands =
-    pip install -e .[test]
     py.test tests
 deps =
+    .[test]
     wtf: WTForms==1.0.5
-    wtf2: WTForms>=2.0
+    wtf2: WTForms==2.1


### PR DESCRIPTION
The latest version which makes use of `StringField` instead of `TextField` introduce some cahnges for those using `StringField` and child because `StringField` wasn't inheriting from `TextField`.
Most of changes are simply handled by inheriting of `Field` instead of `StringField` to avoid the brutal `self.data = ''` but for those which are really `StringField` (ie. expected type is a string), the default value was ignored.

So this PR properly handle default value for `StringField`.

While testing, I noticed some minor glitches I fixed:
- Python 3.6 was not supported
- it was tested against WTForms 2.0, latest is 2.1 
- `tox.ini` wasn't up to date (still testing against Python 2.6)
- there was a naming conflict between some test classes