### PR TITLE
Replace wtforms.ext.sqlalchemy with wtforms_sqlalchemy if it's installed

### DIFF
--- a/wtforms_json/__init__.py
+++ b/wtforms_json/__init__.py
@@ -3,13 +3,20 @@ import collections
 import six
 from wtforms import Form
 try:
-    from wtforms.ext.sqlalchemy.fields import (
+    from wtforms_sqlalchemy.fields import (
         QuerySelectField,
         QuerySelectMultipleField
     )
     HAS_SQLALCHEMY_SUPPORT = True
 except ImportError:
-    HAS_SQLALCHEMY_SUPPORT = False
+    try:
+        from wtforms.ext.sqlalchemy.fields import (
+            QuerySelectField,
+            QuerySelectMultipleField
+        )
+        HAS_SQLALCHEMY_SUPPORT = True
+    except ImportError:
+        HAS_SQLALCHEMY_SUPPORT = False
 from wtforms.fields import (
     _unset_value,
     BooleanField,


### PR DESCRIPTION
* `wtformsext.sqlalchemy` will be removed in WTForms 3.0
  and shows DeprecationWarning since WTForms 2.0
* Import `wtforms_sqlalchemy` if it's installed.
  If not so, import `wtforms.ext.sqlalchemy`.