### PR TITLE
Fix WTForms version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'WTForms>=1.0.2',
+        'WTForms>=1.0.5',
         'six>=1.3.0'
     ],
     extras_require=extras_require,


### PR DESCRIPTION
WTForms-JSON 0.2.8 should have updated the wtforms requirement for version >= 1.0.5, but that was not done. Relevant commits: [wtforms-json 0.2.8](https://github.com/kvesteri/wtforms-json/commit/02b5b43bfc4bb0d046e5d9f90df2dea29c155a2d) depends on [wtforms 1.0.5](https://github.com/wtforms/wtforms/commit/04bc9c137c021fc14e3382400ba1e7ab93498a96). The tests are also using wtforms 1.0.5, which is why this mistake was not found.

Trying to use wtforms < 1.0.5 will cause the following error when `wtforms_json.init()` is called:
```
  File "/home/ubuntu/virtualenvs/venv-2.7.11/lib/python2.7/site-packages/wtforms_json/__init__.py", line 282, in init
    BooleanField.false_values = BooleanField.false_values + (False,)
AttributeError: type object 'BooleanField' has no attribute 'false_values'
```