### PR TITLE
Code in docs does not produce specified data.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Notice how we are initalizing the form using :meth:`from_json` class  method::
 
 
     from wtforms import Form
-    from wtforms.fields import BooleanField, TextField
+    from wtforms.fields import BooleanField, FormField, TextField
 
 
     class LocationForm(Form):
@@ -53,6 +53,7 @@ Notice how we are initalizing the form using :meth:`from_json` class  method::
     class EventForm(Form):
         name = TextField()
         is_public = BooleanField()
+        location = FormField(LocationForm)
 
 
     json = {


### PR DESCRIPTION
In the documentation, the first example demonstrates initialising
an `EventForm` instance with some example data (`json`).

The next section, "Using patch_data" shows some data which it states
is from the first example:

```
>>> form.data
{
    'name': 'First Event',
    'is_public': False,
    'location': {
        'name': 'some location',
        'address': None
    }
}
```

but running the code from the first example produces:

`{'name': 'First Event', 'is_public': False}`

The `LocationForm` defined in the first example needs to be included
in `EventForm` as a `FormField` to produce the data shown in the
"Using patch_data" section.