### PR TITLE
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working

### DIFF
--- a/wtforms_json/__init__.py
+++ b/wtforms_json/__init__.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    from collections.abc import Mapping, MutableMapping
+except:
+    from collections import Mapping, MutableMapping
 
 import six
 from wtforms import Form
@@ -57,7 +60,7 @@ def flatten_json(
         >>> flatten_json(MyForm, {'a': {'b': 'c'}})
         {'a-b': 'c'}
     """
-    if not isinstance(json, collections.Mapping):
+    if not isinstance(json, Mapping):
         raise InvalidData(
             u'This function only accepts dict-like data structures.'
         )
@@ -81,7 +84,7 @@ def flatten_json(
                 raise InvalidData(u"Key '%s' is not valid field class." % key)
 
         new_key = parent_key + separator + key if parent_key else key
-        if isinstance(value, collections.MutableMapping):
+        if isinstance(value, MutableMapping):
             if issubclass(field_class, FormField):
                 nested_form_class = unbound_field.bind(Form(), '').form_class
                 items.extend(


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3